### PR TITLE
Added command that transforms current file variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Use command as a placeholder where WSL path for the `workspaceFolder` is require
 
 ## Features
 
-This extension returns the `workspaceFolder` path, converted from Windows path format to WSL path format. For example, a `workspaceFolder` with a windows path of `c:\\Users\\Me\\Projects\\project` would return a WSL path of `/mnt/c/Users/Me/Projects/project`.
+This extension returns some VS Code workspace file variables, converted from Windows path format to WSL path format. For example, a `workspaceFolder` with a windows path of `c:\\Users\\Me\\Projects\\project` would return a WSL path of `/mnt/c/Users/Me/Projects/project`.
 
 ## Requirements
 
@@ -17,9 +17,10 @@ This extension returns the `workspaceFolder` path, converted from Windows path f
 
 ## Extension Settings
 
-This extension contributes the following command:
+This extension contributes the following commands:
 
 - `extension.vscode-wsl-workspaceFolder`: returns WSL format path string to workspaceFolder
+- `extension.vscode-wsl-workspaceCurrentFile`: returns WSL format path string to the currently open file in your workspace
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,35 +1,35 @@
 {
     "name": "vscode-wsl-workspacefolder",
-    "version": "1.0.2",
+    "version": "1.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
-            "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "7.0.0-beta.51"
+                "@babel/highlight": "^7.0.0"
             }
         },
         "@babel/generator": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
-            "integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+            "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0-beta.51",
+                "@babel/types": "^7.4.0",
                 "jsesc": "^2.5.1",
-                "lodash": "^4.17.5",
+                "lodash": "^4.17.11",
                 "source-map": "^0.5.0",
                 "trim-right": "^1.0.1"
             },
             "dependencies": {
                 "jsesc": {
-                    "version": "2.5.1",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-                    "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+                    "version": "2.5.2",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
                     "dev": true
                 },
                 "source-map": {
@@ -41,89 +41,112 @@
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
-            "integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+            "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "7.0.0-beta.51",
-                "@babel/template": "7.0.0-beta.51",
-                "@babel/types": "7.0.0-beta.51"
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
-            "integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0-beta.51"
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
-            "integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+            "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0-beta.51"
+                "@babel/types": "^7.4.0"
             }
         },
         "@babel/highlight": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
-            "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.0",
                 "esutils": "^2.0.2",
-                "js-tokens": "^3.0.0"
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                    "dev": true
+                }
             }
         },
         "@babel/parser": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
-            "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+            "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
             "dev": true
         },
         "@babel/template": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
-            "integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+            "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.51",
-                "@babel/parser": "7.0.0-beta.51",
-                "@babel/types": "7.0.0-beta.51",
-                "lodash": "^4.17.5"
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.4.0",
+                "@babel/types": "^7.4.0"
             }
         },
         "@babel/traverse": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
-            "integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+            "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.51",
-                "@babel/generator": "7.0.0-beta.51",
-                "@babel/helper-function-name": "7.0.0-beta.51",
-                "@babel/helper-split-export-declaration": "7.0.0-beta.51",
-                "@babel/parser": "7.0.0-beta.51",
-                "@babel/types": "7.0.0-beta.51",
-                "debug": "^3.1.0",
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.4.0",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.4.0",
+                "@babel/parser": "^7.4.3",
+                "@babel/types": "^7.4.0",
+                "debug": "^4.1.0",
                 "globals": "^11.1.0",
-                "invariant": "^2.2.0",
-                "lodash": "^4.17.5"
+                "lodash": "^4.17.11"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
             }
         },
         "@babel/types": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
-            "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+            "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
             "dev": true,
             "requires": {
                 "esutils": "^2.0.2",
-                "lodash": "^4.17.5",
+                "lodash": "^4.17.11",
                 "to-fast-properties": "^2.0.0"
             },
             "dependencies": {
@@ -1182,9 +1205,9 @@
             "dev": true
         },
         "backbone": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
-            "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+            "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
             "dev": true,
             "requires": {
                 "underscore": ">=1.8.3"
@@ -1238,9 +1261,9 @@
             "optional": true
         },
         "blob": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-            "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+            "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
             "dev": true
         },
         "block-stream": {
@@ -1252,27 +1275,27 @@
             }
         },
         "bluebird": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-            "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+            "version": "3.5.4",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+            "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
             "dev": true
         },
         "body-parser": {
-            "version": "1.18.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-            "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+            "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
                 "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "~1.1.1",
-                "http-errors": "~1.6.2",
-                "iconv-lite": "0.4.19",
+                "depd": "~1.1.2",
+                "http-errors": "~1.6.3",
+                "iconv-lite": "0.4.23",
                 "on-finished": "~2.3.0",
-                "qs": "6.5.1",
-                "raw-body": "2.3.2",
-                "type-is": "~1.6.15"
+                "qs": "6.5.2",
+                "raw-body": "2.3.3",
+                "type-is": "~1.6.16"
             },
             "dependencies": {
                 "debug": {
@@ -1283,18 +1306,6 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
-                },
-                "iconv-lite": {
-                    "version": "0.4.19",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-                    "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-                    "dev": true
-                },
-                "qs": {
-                    "version": "6.5.1",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-                    "dev": true
                 }
             }
         },
@@ -1500,15 +1511,13 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                     "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "is-glob": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "is-extglob": "^1.0.0"
                     }
@@ -1944,9 +1953,9 @@
             }
         },
         "engine.io": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
-            "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.3.2.tgz",
+            "integrity": "sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==",
             "dev": true,
             "requires": {
                 "accepts": "~1.3.4",
@@ -1954,13 +1963,13 @@
                 "cookie": "0.3.1",
                 "debug": "~3.1.0",
                 "engine.io-parser": "~2.1.0",
-                "ws": "~3.3.1"
+                "ws": "~6.1.0"
             }
         },
         "engine.io-client": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
-            "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.2.tgz",
+            "integrity": "sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==",
             "dev": true,
             "requires": {
                 "component-emitter": "1.2.1",
@@ -1971,21 +1980,21 @@
                 "indexof": "0.0.1",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "ws": "~3.3.1",
+                "ws": "~6.1.0",
                 "xmlhttprequest-ssl": "~1.5.4",
                 "yeast": "0.1.2"
             }
         },
         "engine.io-parser": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-            "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+            "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
             "dev": true,
             "requires": {
                 "after": "0.8.2",
                 "arraybuffer.slice": "~0.0.7",
                 "base64-arraybuffer": "0.1.5",
-                "blob": "0.0.4",
+                "blob": "0.0.5",
                 "has-binary2": "~1.0.2"
             }
         },
@@ -2249,9 +2258,9 @@
             }
         },
         "esprima": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
         },
         "esquery": {
@@ -2365,14 +2374,14 @@
             }
         },
         "express": {
-            "version": "4.16.3",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
-            "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+            "version": "4.16.4",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+            "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
             "dev": true,
             "requires": {
                 "accepts": "~1.3.5",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.18.2",
+                "body-parser": "1.18.3",
                 "content-disposition": "0.5.2",
                 "content-type": "~1.0.4",
                 "cookie": "0.3.1",
@@ -2389,10 +2398,10 @@
                 "on-finished": "~2.3.0",
                 "parseurl": "~1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.3",
-                "qs": "6.5.1",
+                "proxy-addr": "~2.0.4",
+                "qs": "6.5.2",
                 "range-parser": "~1.2.0",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "send": "0.16.2",
                 "serve-static": "1.13.2",
                 "setprototypeof": "1.1.0",
@@ -2410,18 +2419,6 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
-                },
-                "qs": {
-                    "version": "6.5.1",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-                    "dev": true
-                },
-                "safe-buffer": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-                    "dev": true
                 }
             }
         },
@@ -2609,12 +2606,29 @@
             }
         },
         "follow-redirects": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
-            "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+            "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
             "dev": true,
             "requires": {
-                "debug": "^3.1.0"
+                "debug": "^3.2.6"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
             }
         },
         "for-each": {
@@ -2720,8 +2734,7 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -2742,14 +2755,12 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2770,14 +2781,12 @@
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -2922,7 +2931,6 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -2930,14 +2938,12 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -2956,7 +2962,6 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3050,7 +3055,6 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3136,8 +3140,7 @@
                 "safe-buffer": {
                     "version": "5.1.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -3193,7 +3196,6 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3237,14 +3239,12 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "yallist": {
                     "version": "3.0.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 }
             }
         },
@@ -3380,15 +3380,13 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                     "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "is-glob": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "is-extglob": "^1.0.0"
                     }
@@ -3861,9 +3859,9 @@
             "dev": true
         },
         "ipaddr.js": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
-            "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+            "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
             "dev": true
         },
         "is": {
@@ -4152,23 +4150,23 @@
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "istanbul-lib-coverage": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-            "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+            "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
             "dev": true
         },
         "istanbul-lib-instrument": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.1.tgz",
-            "integrity": "sha512-h9Vg3nfbxrF0PK0kZiNiMAyL8zXaLiBP/BXniaKSwVvAi1TaumYV2b0wPdmy1CRX3irYbYD1p4Wjbv4uyECiiQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+            "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
             "dev": true,
             "requires": {
-                "@babel/generator": "7.0.0-beta.51",
-                "@babel/parser": "7.0.0-beta.51",
-                "@babel/template": "7.0.0-beta.51",
-                "@babel/traverse": "7.0.0-beta.51",
-                "@babel/types": "7.0.0-beta.51",
-                "istanbul-lib-coverage": "^2.0.1",
+                "@babel/generator": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/template": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "istanbul-lib-coverage": "^2.0.3",
                 "semver": "^5.5.0"
             }
         },
@@ -4179,9 +4177,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.12.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-            "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -4325,9 +4323,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.10",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+            "version": "4.17.11",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
             "dev": true
         },
         "lodash._baseflatten": {
@@ -4615,8 +4613,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                     "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "is-glob": {
                     "version": "2.0.1",
@@ -4680,9 +4677,9 @@
             "dev": true
         },
         "minipass": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
-            "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+            "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
             "dev": true,
             "requires": {
                 "safe-buffer": "^5.1.2",
@@ -4690,9 +4687,9 @@
             },
             "dependencies": {
                 "yallist": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-                    "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
                     "dev": true
                 }
             }
@@ -4761,9 +4758,9 @@
             }
         },
         "mustache": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
-            "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
+            "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA==",
             "dev": true
         },
         "mute-stream": {
@@ -4797,13 +4794,14 @@
             "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
         },
         "node-notifier": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-            "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+            "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
             "dev": true,
             "requires": {
                 "growly": "^1.3.0",
-                "semver": "^5.4.1",
+                "is-wsl": "^1.1.0",
+                "semver": "^5.5.0",
                 "shellwords": "^0.1.1",
                 "which": "^1.3.0"
             }
@@ -4881,91 +4879,52 @@
             "dev": true
         },
         "nyc": {
-            "version": "12.0.2",
-            "resolved": "https://registry.npmjs.org/nyc/-/nyc-12.0.2.tgz",
-            "integrity": "sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=",
+            "version": "13.3.0",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.3.0.tgz",
+            "integrity": "sha512-P+FwIuro2aFG6B0Esd9ZDWUd51uZrAEoGutqZxzrVmYl3qSfkLgcQpBPBjtDFsUQLFY1dvTQJPOyeqr8S9GF8w==",
             "dev": true,
             "requires": {
                 "archy": "^1.0.0",
                 "arrify": "^1.0.1",
-                "caching-transform": "^1.0.0",
-                "convert-source-map": "^1.5.1",
-                "debug-log": "^1.0.1",
-                "default-require-extensions": "^1.0.0",
-                "find-cache-dir": "^0.1.1",
-                "find-up": "^2.1.0",
-                "foreground-child": "^1.5.3",
-                "glob": "^7.0.6",
-                "istanbul-lib-coverage": "^1.2.0",
-                "istanbul-lib-hook": "^1.1.0",
-                "istanbul-lib-instrument": "^2.1.0",
-                "istanbul-lib-report": "^1.1.3",
-                "istanbul-lib-source-maps": "^1.2.5",
-                "istanbul-reports": "^1.4.1",
-                "md5-hex": "^1.2.0",
+                "caching-transform": "^3.0.1",
+                "convert-source-map": "^1.6.0",
+                "find-cache-dir": "^2.0.0",
+                "find-up": "^3.0.0",
+                "foreground-child": "^1.5.6",
+                "glob": "^7.1.3",
+                "istanbul-lib-coverage": "^2.0.3",
+                "istanbul-lib-hook": "^2.0.3",
+                "istanbul-lib-instrument": "^3.1.0",
+                "istanbul-lib-report": "^2.0.4",
+                "istanbul-lib-source-maps": "^3.0.2",
+                "istanbul-reports": "^2.1.1",
+                "make-dir": "^1.3.0",
                 "merge-source-map": "^1.1.0",
-                "micromatch": "^3.1.10",
-                "mkdirp": "^0.5.0",
-                "resolve-from": "^2.0.0",
-                "rimraf": "^2.6.2",
-                "signal-exit": "^3.0.1",
+                "resolve-from": "^4.0.0",
+                "rimraf": "^2.6.3",
+                "signal-exit": "^3.0.2",
                 "spawn-wrap": "^1.4.2",
-                "test-exclude": "^4.2.0",
-                "yargs": "11.1.0",
-                "yargs-parser": "^8.0.0"
+                "test-exclude": "^5.1.0",
+                "uuid": "^3.3.2",
+                "yargs": "^12.0.5",
+                "yargs-parser": "^11.1.1"
             },
             "dependencies": {
-                "align-text": {
-                    "version": "0.1.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "kind-of": "^3.0.2",
-                        "longest": "^1.0.1",
-                        "repeat-string": "^1.5.2"
-                    }
-                },
-                "amdefine": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true
-                },
                 "ansi-regex": {
                     "version": "3.0.0",
                     "bundled": true,
                     "dev": true
                 },
                 "append-transform": {
-                    "version": "0.4.0",
+                    "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "default-require-extensions": "^1.0.0"
+                        "default-require-extensions": "^2.0.0"
                     }
                 },
                 "archy": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "arr-diff": {
-                    "version": "4.0.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "arr-flatten": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "arr-union": {
-                    "version": "3.1.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "array-unique": {
-                    "version": "0.3.2",
                     "bundled": true,
                     "dev": true
                 },
@@ -4974,80 +4933,18 @@
                     "bundled": true,
                     "dev": true
                 },
-                "assign-symbols": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true
-                },
                 "async": {
-                    "version": "1.5.2",
+                    "version": "2.6.2",
                     "bundled": true,
-                    "dev": true
-                },
-                "atob": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.11"
+                    }
                 },
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true
-                },
-                "base": {
-                    "version": "0.11.2",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "cache-base": "^1.0.1",
-                        "class-utils": "^0.3.5",
-                        "component-emitter": "^1.2.1",
-                        "define-property": "^1.0.0",
-                        "isobject": "^3.0.1",
-                        "mixin-deep": "^1.2.0",
-                        "pascalcase": "^0.1.1"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-descriptor": "^1.0.0"
-                            }
-                        },
-                        "is-accessor-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "kind-of": "^6.0.0"
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "kind-of": "^6.0.0"
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-accessor-descriptor": "^1.0.0",
-                                "is-data-descriptor": "^1.0.0",
-                                "kind-of": "^6.0.2"
-                            }
-                        },
-                        "kind-of": {
-                            "version": "6.0.2",
-                            "bundled": true,
-                            "dev": true
-                        }
-                    }
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
@@ -5058,118 +4955,30 @@
                         "concat-map": "0.0.1"
                     }
                 },
-                "braces": {
-                    "version": "2.3.2",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "builtin-modules": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "cache-base": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "collection-visit": "^1.0.0",
-                        "component-emitter": "^1.2.1",
-                        "get-value": "^2.0.6",
-                        "has-value": "^1.0.0",
-                        "isobject": "^3.0.1",
-                        "set-value": "^2.0.0",
-                        "to-object-path": "^0.3.0",
-                        "union-value": "^1.0.0",
-                        "unset-value": "^1.0.0"
-                    }
-                },
                 "caching-transform": {
-                    "version": "1.0.1",
+                    "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "md5-hex": "^1.2.0",
-                        "mkdirp": "^0.5.1",
-                        "write-file-atomic": "^1.1.4"
+                        "hasha": "^3.0.0",
+                        "make-dir": "^1.3.0",
+                        "package-hash": "^3.0.0",
+                        "write-file-atomic": "^2.3.0"
                     }
                 },
                 "camelcase": {
-                    "version": "1.2.1",
+                    "version": "5.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "center-align": {
-                    "version": "0.1.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "align-text": "^0.1.3",
-                        "lazy-cache": "^1.0.3"
-                    }
-                },
-                "class-utils": {
-                    "version": "0.3.6",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "arr-union": "^3.1.0",
-                        "define-property": "^0.2.5",
-                        "isobject": "^3.0.0",
-                        "static-extend": "^0.1.1"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "0.2.5",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-descriptor": "^0.1.0"
-                            }
-                        }
-                    }
+                    "dev": true
                 },
                 "cliui": {
-                    "version": "2.1.0",
+                    "version": "4.1.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
-                        "center-align": "^0.1.1",
-                        "right-align": "^0.1.1",
-                        "wordwrap": "0.0.2"
-                    },
-                    "dependencies": {
-                        "wordwrap": {
-                            "version": "0.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "code-point-at": {
@@ -5177,22 +4986,14 @@
                     "bundled": true,
                     "dev": true
                 },
-                "collection-visit": {
-                    "version": "1.0.0",
+                "commander": {
+                    "version": "2.17.1",
                     "bundled": true,
                     "dev": true,
-                    "requires": {
-                        "map-visit": "^1.0.0",
-                        "object-visit": "^1.0.0"
-                    }
+                    "optional": true
                 },
                 "commondir": {
                     "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "component-emitter": {
-                    "version": "1.2.1",
                     "bundled": true,
                     "dev": true
                 },
@@ -5202,14 +5003,12 @@
                     "dev": true
                 },
                 "convert-source-map": {
-                    "version": "1.5.1",
+                    "version": "1.6.0",
                     "bundled": true,
-                    "dev": true
-                },
-                "copy-descriptor": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.1"
+                    }
                 },
                 "cross-spawn": {
                     "version": "4.0.2",
@@ -5221,93 +5020,54 @@
                     }
                 },
                 "debug": {
-                    "version": "3.1.0",
+                    "version": "4.1.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
-                },
-                "debug-log": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true
                 },
                 "decamelize": {
                     "version": "1.2.0",
                     "bundled": true,
                     "dev": true
                 },
-                "decode-uri-component": {
-                    "version": "0.2.0",
-                    "bundled": true,
-                    "dev": true
-                },
                 "default-require-extensions": {
-                    "version": "1.0.0",
+                    "version": "2.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "strip-bom": "^2.0.0"
+                        "strip-bom": "^3.0.0"
                     }
                 },
-                "define-property": {
-                    "version": "2.0.2",
+                "end-of-stream": {
+                    "version": "1.4.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.2",
-                        "isobject": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "is-accessor-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "kind-of": "^6.0.0"
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "kind-of": "^6.0.0"
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-accessor-descriptor": "^1.0.0",
-                                "is-data-descriptor": "^1.0.0",
-                                "kind-of": "^6.0.2"
-                            }
-                        },
-                        "kind-of": {
-                            "version": "6.0.2",
-                            "bundled": true,
-                            "dev": true
-                        }
+                        "once": "^1.4.0"
                     }
                 },
                 "error-ex": {
-                    "version": "1.3.1",
+                    "version": "1.3.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "is-arrayish": "^0.2.1"
                     }
                 },
+                "es6-error": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
                 "execa": {
-                    "version": "0.7.0",
+                    "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
                         "is-stream": "^1.1.0",
                         "npm-run-path": "^2.0.0",
                         "p-finally": "^1.0.0",
@@ -5316,183 +5076,36 @@
                     },
                     "dependencies": {
                         "cross-spawn": {
-                            "version": "5.1.0",
+                            "version": "6.0.5",
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "lru-cache": "^4.0.1",
+                                "nice-try": "^1.0.4",
+                                "path-key": "^2.0.1",
+                                "semver": "^5.5.0",
                                 "shebang-command": "^1.2.0",
                                 "which": "^1.2.9"
                             }
                         }
                     }
                 },
-                "expand-brackets": {
-                    "version": "2.1.4",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "debug": "^2.3.3",
-                        "define-property": "^0.2.5",
-                        "extend-shallow": "^2.0.1",
-                        "posix-character-classes": "^0.1.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "debug": {
-                            "version": "2.6.9",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "ms": "2.0.0"
-                            }
-                        },
-                        "define-property": {
-                            "version": "0.2.5",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-descriptor": "^0.1.0"
-                            }
-                        },
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "extend-shallow": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "assign-symbols": "^1.0.0",
-                        "is-extendable": "^1.0.1"
-                    },
-                    "dependencies": {
-                        "is-extendable": {
-                            "version": "1.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-plain-object": "^2.0.4"
-                            }
-                        }
-                    }
-                },
-                "extglob": {
-                    "version": "2.0.4",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "array-unique": "^0.3.2",
-                        "define-property": "^1.0.0",
-                        "expand-brackets": "^2.1.4",
-                        "extend-shallow": "^2.0.1",
-                        "fragment-cache": "^0.2.1",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-descriptor": "^1.0.0"
-                            }
-                        },
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        },
-                        "is-accessor-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "kind-of": "^6.0.0"
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "kind-of": "^6.0.0"
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-accessor-descriptor": "^1.0.0",
-                                "is-data-descriptor": "^1.0.0",
-                                "kind-of": "^6.0.2"
-                            }
-                        },
-                        "kind-of": {
-                            "version": "6.0.2",
-                            "bundled": true,
-                            "dev": true
-                        }
-                    }
-                },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
                 "find-cache-dir": {
-                    "version": "0.1.1",
+                    "version": "2.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "commondir": "^1.0.1",
-                        "mkdirp": "^0.5.1",
-                        "pkg-dir": "^1.0.0"
+                        "make-dir": "^1.0.0",
+                        "pkg-dir": "^3.0.0"
                     }
                 },
                 "find-up": {
-                    "version": "2.1.0",
+                    "version": "3.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "^3.0.0"
                     }
-                },
-                "for-in": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
                 },
                 "foreground-child": {
                     "version": "1.5.6",
@@ -5503,36 +5116,26 @@
                         "signal-exit": "^3.0.0"
                     }
                 },
-                "fragment-cache": {
-                    "version": "0.2.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "map-cache": "^0.2.2"
-                    }
-                },
                 "fs.realpath": {
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true
                 },
                 "get-caller-file": {
-                    "version": "1.0.2",
+                    "version": "1.0.3",
                     "bundled": true,
                     "dev": true
                 },
                 "get-stream": {
-                    "version": "3.0.0",
+                    "version": "4.1.0",
                     "bundled": true,
-                    "dev": true
-                },
-                "get-value": {
-                    "version": "2.0.6",
-                    "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
                 },
                 "glob": {
-                    "version": "7.1.2",
+                    "version": "7.1.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -5545,62 +5148,43 @@
                     }
                 },
                 "graceful-fs": {
-                    "version": "4.1.11",
+                    "version": "4.1.15",
                     "bundled": true,
                     "dev": true
                 },
                 "handlebars": {
-                    "version": "4.0.11",
+                    "version": "4.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "async": "^1.4.0",
+                        "async": "^2.5.0",
                         "optimist": "^0.6.1",
-                        "source-map": "^0.4.4",
-                        "uglify-js": "^2.6"
+                        "source-map": "^0.6.1",
+                        "uglify-js": "^3.1.4"
                     },
                     "dependencies": {
                         "source-map": {
-                            "version": "0.4.4",
+                            "version": "0.6.1",
                             "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "amdefine": ">=0.0.4"
-                            }
+                            "dev": true
                         }
                     }
                 },
-                "has-value": {
-                    "version": "1.0.0",
+                "has-flag": {
+                    "version": "3.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "get-value": "^2.0.6",
-                        "has-values": "^1.0.0",
-                        "isobject": "^3.0.0"
-                    }
+                    "dev": true
                 },
-                "has-values": {
-                    "version": "1.0.0",
+                "hasha": {
+                    "version": "3.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-number": "^3.0.0",
-                        "kind-of": "^4.0.0"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "4.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
+                        "is-stream": "^1.0.1"
                     }
                 },
                 "hosted-git-info": {
-                    "version": "2.6.0",
+                    "version": "2.7.1",
                     "bundled": true,
                     "dev": true
                 },
@@ -5624,63 +5208,12 @@
                     "dev": true
                 },
                 "invert-kv": {
-                    "version": "1.0.0",
+                    "version": "2.0.0",
                     "bundled": true,
                     "dev": true
-                },
-                "is-accessor-descriptor": {
-                    "version": "0.1.6",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    }
                 },
                 "is-arrayish": {
                     "version": "0.2.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "is-buffer": {
-                    "version": "1.1.6",
-                    "bundled": true,
-                    "dev": true
-                },
-                "is-builtin-module": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "builtin-modules": "^1.0.0"
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "0.1.4",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    }
-                },
-                "is-descriptor": {
-                    "version": "0.1.6",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "is-accessor-descriptor": "^0.1.6",
-                        "is-data-descriptor": "^0.1.4",
-                        "kind-of": "^5.0.0"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "5.1.0",
-                            "bundled": true,
-                            "dev": true
-                        }
-                    }
-                },
-                "is-extendable": {
-                    "version": "0.1.1",
                     "bundled": true,
                     "dev": true
                 },
@@ -5689,54 +5222,8 @@
                     "bundled": true,
                     "dev": true
                 },
-                "is-number": {
-                    "version": "3.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    }
-                },
-                "is-odd": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "is-number": "^4.0.0"
-                    },
-                    "dependencies": {
-                        "is-number": {
-                            "version": "4.0.0",
-                            "bundled": true,
-                            "dev": true
-                        }
-                    }
-                },
-                "is-plain-object": {
-                    "version": "2.0.4",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "isobject": "^3.0.1"
-                    }
-                },
                 "is-stream": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "is-utf8": {
-                    "version": "0.2.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "is-windows": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
-                },
-                "isarray": {
-                    "version": "1.0.0",
                     "bundled": true,
                     "dev": true
                 },
@@ -5745,128 +5232,111 @@
                     "bundled": true,
                     "dev": true
                 },
-                "isobject": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true
-                },
                 "istanbul-lib-coverage": {
-                    "version": "1.2.0",
+                    "version": "2.0.3",
                     "bundled": true,
                     "dev": true
                 },
                 "istanbul-lib-hook": {
-                    "version": "1.1.0",
+                    "version": "2.0.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "append-transform": "^0.4.0"
+                        "append-transform": "^1.0.0"
                     }
                 },
                 "istanbul-lib-report": {
-                    "version": "1.1.3",
+                    "version": "2.0.4",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "istanbul-lib-coverage": "^1.1.2",
-                        "mkdirp": "^0.5.1",
-                        "path-parse": "^1.0.5",
-                        "supports-color": "^3.1.2"
+                        "istanbul-lib-coverage": "^2.0.3",
+                        "make-dir": "^1.3.0",
+                        "supports-color": "^6.0.0"
                     },
                     "dependencies": {
-                        "has-flag": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true
-                        },
                         "supports-color": {
-                            "version": "3.2.3",
+                            "version": "6.1.0",
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "has-flag": "^1.0.0"
+                                "has-flag": "^3.0.0"
                             }
                         }
                     }
                 },
                 "istanbul-lib-source-maps": {
-                    "version": "1.2.5",
+                    "version": "3.0.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debug": "^3.1.0",
-                        "istanbul-lib-coverage": "^1.2.0",
-                        "mkdirp": "^0.5.1",
-                        "rimraf": "^2.6.1",
-                        "source-map": "^0.5.3"
-                    }
-                },
-                "istanbul-reports": {
-                    "version": "1.4.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "handlebars": "^4.0.3"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                },
-                "lazy-cache": {
-                    "version": "1.0.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "lcid": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "invert-kv": "^1.0.0"
-                    }
-                },
-                "load-json-file": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
+                        "debug": "^4.1.1",
+                        "istanbul-lib-coverage": "^2.0.3",
+                        "make-dir": "^1.3.0",
+                        "rimraf": "^2.6.2",
+                        "source-map": "^0.6.1"
                     },
                     "dependencies": {
-                        "path-exists": {
-                            "version": "3.0.0",
+                        "source-map": {
+                            "version": "0.6.1",
                             "bundled": true,
                             "dev": true
                         }
                     }
                 },
-                "longest": {
-                    "version": "1.0.1",
+                "istanbul-reports": {
+                    "version": "2.1.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true
+                    "requires": {
+                        "handlebars": "^4.1.0"
+                    }
+                },
+                "json-parse-better-errors": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^2.0.0"
+                    }
+                },
+                "load-json-file": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.11",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash.flattendeep": {
+                    "version": "4.4.0",
+                    "bundled": true,
+                    "dev": true
                 },
                 "lru-cache": {
-                    "version": "4.1.3",
+                    "version": "4.1.5",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -5874,38 +5344,30 @@
                         "yallist": "^2.1.2"
                     }
                 },
-                "map-cache": {
-                    "version": "0.2.2",
-                    "bundled": true,
-                    "dev": true
-                },
-                "map-visit": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "object-visit": "^1.0.0"
-                    }
-                },
-                "md5-hex": {
+                "make-dir": {
                     "version": "1.3.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "md5-o-matic": "^0.1.1"
+                        "pify": "^3.0.0"
                     }
                 },
-                "md5-o-matic": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "mem": {
-                    "version": "1.1.0",
+                "map-age-cleaner": {
+                    "version": "0.1.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "^1.0.0"
+                        "p-defer": "^1.0.0"
+                    }
+                },
+                "mem": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "map-age-cleaner": "^0.1.1",
+                        "mimic-fn": "^1.0.0",
+                        "p-is-promise": "^2.0.0"
                     }
                 },
                 "merge-source-map": {
@@ -5918,33 +5380,6 @@
                     "dependencies": {
                         "source-map": {
                             "version": "0.6.1",
-                            "bundled": true,
-                            "dev": true
-                        }
-                    }
-                },
-                "micromatch": {
-                    "version": "3.1.10",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "6.0.2",
                             "bundled": true,
                             "dev": true
                         }
@@ -5964,28 +5399,9 @@
                     }
                 },
                 "minimist": {
-                    "version": "0.0.8",
+                    "version": "0.0.10",
                     "bundled": true,
                     "dev": true
-                },
-                "mixin-deep": {
-                    "version": "1.3.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "for-in": "^1.0.2",
-                        "is-extendable": "^1.0.1"
-                    },
-                    "dependencies": {
-                        "is-extendable": {
-                            "version": "1.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-plain-object": "^2.0.4"
-                            }
-                        }
-                    }
                 },
                 "mkdirp": {
                     "version": "0.5.1",
@@ -5993,46 +5409,32 @@
                     "dev": true,
                     "requires": {
                         "minimist": "0.0.8"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "nanomatch": {
-                    "version": "1.2.9",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "fragment-cache": "^0.2.1",
-                        "is-odd": "^2.0.0",
-                        "is-windows": "^1.0.2",
-                        "kind-of": "^6.0.2",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
-                        "kind-of": {
-                            "version": "6.0.2",
+                        "minimist": {
+                            "version": "0.0.8",
                             "bundled": true,
                             "dev": true
                         }
                     }
                 },
+                "ms": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "nice-try": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true
+                },
                 "normalize-package-data": {
-                    "version": "2.4.0",
+                    "version": "2.5.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
+                        "resolve": "^1.10.0",
                         "semver": "2 || 3 || 4 || 5",
                         "validate-npm-package-license": "^3.0.1"
                     }
@@ -6049,47 +5451,6 @@
                     "version": "1.0.1",
                     "bundled": true,
                     "dev": true
-                },
-                "object-assign": {
-                    "version": "4.1.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "object-copy": {
-                    "version": "0.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "copy-descriptor": "^0.1.0",
-                        "define-property": "^0.2.5",
-                        "kind-of": "^3.0.3"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "0.2.5",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-descriptor": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "object-visit": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "isobject": "^3.0.0"
-                    }
-                },
-                "object.pick": {
-                    "version": "1.3.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "isobject": "^3.0.1"
-                    }
                 },
                 "once": {
                     "version": "1.4.0",
@@ -6114,61 +5475,75 @@
                     "dev": true
                 },
                 "os-locale": {
-                    "version": "2.1.0",
+                    "version": "3.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "execa": "^0.7.0",
-                        "lcid": "^1.0.0",
-                        "mem": "^1.1.0"
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
                     }
+                },
+                "p-defer": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
                 },
                 "p-finally": {
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true
                 },
-                "p-limit": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "p-try": "^1.0.0"
-                    }
-                },
-                "p-locate": {
+                "p-is-promise": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^1.1.0"
-                    }
-                },
-                "p-try": {
-                    "version": "1.0.0",
-                    "bundled": true,
                     "dev": true
                 },
-                "parse-json": {
-                    "version": "2.2.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "error-ex": "^1.2.0"
-                    }
-                },
-                "pascalcase": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "path-exists": {
+                "p-limit": {
                     "version": "2.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "^2.0.0"
+                        "p-try": "^2.0.0"
                     }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "package-hash": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.15",
+                        "hasha": "^3.0.0",
+                        "lodash.flattendeep": "^4.4.0",
+                        "release-zalgo": "^1.0.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
@@ -6181,115 +5556,71 @@
                     "dev": true
                 },
                 "path-parse": {
-                    "version": "1.0.5",
+                    "version": "1.0.6",
                     "bundled": true,
                     "dev": true
                 },
                 "path-type": {
-                    "version": "1.1.0",
+                    "version": "3.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "pify": "^3.0.0"
                     }
                 },
                 "pify": {
-                    "version": "2.3.0",
+                    "version": "3.0.0",
                     "bundled": true,
                     "dev": true
-                },
-                "pinkie": {
-                    "version": "2.0.4",
-                    "bundled": true,
-                    "dev": true
-                },
-                "pinkie-promise": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "pinkie": "^2.0.0"
-                    }
                 },
                 "pkg-dir": {
-                    "version": "1.0.0",
+                    "version": "3.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "find-up": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "find-up": {
-                            "version": "1.1.2",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "path-exists": "^2.0.0",
-                                "pinkie-promise": "^2.0.0"
-                            }
-                        }
+                        "find-up": "^3.0.0"
                     }
-                },
-                "posix-character-classes": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "dev": true
                 },
                 "pseudomap": {
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true
                 },
-                "read-pkg": {
-                    "version": "1.1.0",
+                "pump": {
+                    "version": "3.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "load-json-file": "^1.0.0",
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                },
+                "read-pkg": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^4.0.0",
                         "normalize-package-data": "^2.3.2",
-                        "path-type": "^1.0.0"
+                        "path-type": "^3.0.0"
                     }
                 },
                 "read-pkg-up": {
-                    "version": "1.0.1",
+                    "version": "4.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "find-up": "^1.0.0",
-                        "read-pkg": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "find-up": {
-                            "version": "1.1.2",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "path-exists": "^2.0.0",
-                                "pinkie-promise": "^2.0.0"
-                            }
-                        }
+                        "find-up": "^3.0.0",
+                        "read-pkg": "^3.0.0"
                     }
                 },
-                "regex-not": {
-                    "version": "1.0.2",
+                "release-zalgo": {
+                    "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^3.0.2",
-                        "safe-regex": "^1.1.0"
+                        "es6-error": "^4.0.1"
                     }
-                },
-                "repeat-element": {
-                    "version": "1.1.2",
-                    "bundled": true,
-                    "dev": true
-                },
-                "repeat-string": {
-                    "version": "1.6.1",
-                    "bundled": true,
-                    "dev": true
                 },
                 "require-directory": {
                     "version": "2.1.1",
@@ -6301,48 +5632,34 @@
                     "bundled": true,
                     "dev": true
                 },
-                "resolve-from": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "resolve-url": {
-                    "version": "0.2.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "ret": {
-                    "version": "0.1.15",
-                    "bundled": true,
-                    "dev": true
-                },
-                "right-align": {
-                    "version": "0.1.3",
+                "resolve": {
+                    "version": "1.10.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
-                        "align-text": "^0.1.1"
+                        "path-parse": "^1.0.6"
                     }
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
                 },
                 "rimraf": {
-                    "version": "2.6.2",
+                    "version": "2.6.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "^7.1.3"
                     }
                 },
-                "safe-regex": {
-                    "version": "1.1.0",
+                "safe-buffer": {
+                    "version": "5.1.2",
                     "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "ret": "~0.1.10"
-                    }
+                    "dev": true
                 },
                 "semver": {
-                    "version": "5.5.0",
+                    "version": "5.6.0",
                     "bundled": true,
                     "dev": true
                 },
@@ -6350,27 +5667,6 @@
                     "version": "2.0.0",
                     "bundled": true,
                     "dev": true
-                },
-                "set-value": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.3",
-                        "split-string": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
                 },
                 "shebang-command": {
                     "version": "1.2.0",
@@ -6390,133 +5686,6 @@
                     "bundled": true,
                     "dev": true
                 },
-                "slide": {
-                    "version": "1.1.6",
-                    "bundled": true,
-                    "dev": true
-                },
-                "snapdragon": {
-                    "version": "0.8.2",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "base": "^0.11.1",
-                        "debug": "^2.2.0",
-                        "define-property": "^0.2.5",
-                        "extend-shallow": "^2.0.1",
-                        "map-cache": "^0.2.2",
-                        "source-map": "^0.5.6",
-                        "source-map-resolve": "^0.5.0",
-                        "use": "^3.1.0"
-                    },
-                    "dependencies": {
-                        "debug": {
-                            "version": "2.6.9",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "ms": "2.0.0"
-                            }
-                        },
-                        "define-property": {
-                            "version": "0.2.5",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-descriptor": "^0.1.0"
-                            }
-                        },
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "snapdragon-node": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "define-property": "^1.0.0",
-                        "isobject": "^3.0.0",
-                        "snapdragon-util": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-descriptor": "^1.0.0"
-                            }
-                        },
-                        "is-accessor-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "kind-of": "^6.0.0"
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "kind-of": "^6.0.0"
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-accessor-descriptor": "^1.0.0",
-                                "is-data-descriptor": "^1.0.0",
-                                "kind-of": "^6.0.2"
-                            }
-                        },
-                        "kind-of": {
-                            "version": "6.0.2",
-                            "bundled": true,
-                            "dev": true
-                        }
-                    }
-                },
-                "snapdragon-util": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.2.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "bundled": true,
-                    "dev": true
-                },
-                "source-map-resolve": {
-                    "version": "0.5.2",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "atob": "^2.1.1",
-                        "decode-uri-component": "^0.2.0",
-                        "resolve-url": "^0.2.1",
-                        "source-map-url": "^0.4.0",
-                        "urix": "^0.1.0"
-                    }
-                },
-                "source-map-url": {
-                    "version": "0.4.0",
-                    "bundled": true,
-                    "dev": true
-                },
                 "spawn-wrap": {
                     "version": "1.4.2",
                     "bundled": true,
@@ -6531,7 +5700,7 @@
                     }
                 },
                 "spdx-correct": {
-                    "version": "3.0.0",
+                    "version": "3.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -6540,7 +5709,7 @@
                     }
                 },
                 "spdx-exceptions": {
-                    "version": "2.1.0",
+                    "version": "2.2.0",
                     "bundled": true,
                     "dev": true
                 },
@@ -6554,36 +5723,9 @@
                     }
                 },
                 "spdx-license-ids": {
-                    "version": "3.0.0",
+                    "version": "3.0.3",
                     "bundled": true,
                     "dev": true
-                },
-                "split-string": {
-                    "version": "3.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^3.0.0"
-                    }
-                },
-                "static-extend": {
-                    "version": "0.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "define-property": "^0.2.5",
-                        "object-copy": "^0.1.0"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "0.2.5",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-descriptor": "^0.1.0"
-                            }
-                        }
-                    }
                 },
                 "string-width": {
                     "version": "2.1.1",
@@ -6603,12 +5745,9 @@
                     }
                 },
                 "strip-bom": {
-                    "version": "2.0.0",
+                    "version": "3.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "is-utf8": "^0.2.0"
-                    }
+                    "dev": true
                 },
                 "strip-eof": {
                     "version": "1.0.0",
@@ -6616,166 +5755,41 @@
                     "dev": true
                 },
                 "test-exclude": {
-                    "version": "4.2.1",
+                    "version": "5.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "arrify": "^1.0.1",
-                        "micromatch": "^3.1.8",
-                        "object-assign": "^4.1.0",
-                        "read-pkg-up": "^1.0.1",
+                        "minimatch": "^3.0.4",
+                        "read-pkg-up": "^4.0.0",
                         "require-main-filename": "^1.0.1"
                     }
                 },
-                "to-object-path": {
-                    "version": "0.3.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    }
-                },
-                "to-regex": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "regex-not": "^1.0.2",
-                        "safe-regex": "^1.1.0"
-                    }
-                },
-                "to-regex-range": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
-                    }
-                },
                 "uglify-js": {
-                    "version": "2.8.29",
+                    "version": "3.4.9",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "source-map": "~0.5.1",
-                        "uglify-to-browserify": "~1.0.0",
-                        "yargs": "~3.10.0"
+                        "commander": "~2.17.1",
+                        "source-map": "~0.6.1"
                     },
                     "dependencies": {
-                        "yargs": {
-                            "version": "3.10.0",
+                        "source-map": {
+                            "version": "0.6.1",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "camelcase": "^1.0.2",
-                                "cliui": "^2.1.0",
-                                "decamelize": "^1.0.0",
-                                "window-size": "0.1.0"
-                            }
+                            "optional": true
                         }
                     }
                 },
-                "uglify-to-browserify": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "union-value": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "arr-union": "^3.1.0",
-                        "get-value": "^2.0.6",
-                        "is-extendable": "^0.1.1",
-                        "set-value": "^0.4.3"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        },
-                        "set-value": {
-                            "version": "0.4.3",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "extend-shallow": "^2.0.1",
-                                "is-extendable": "^0.1.1",
-                                "is-plain-object": "^2.0.1",
-                                "to-object-path": "^0.3.0"
-                            }
-                        }
-                    }
-                },
-                "unset-value": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "has-value": "^0.3.1",
-                        "isobject": "^3.0.0"
-                    },
-                    "dependencies": {
-                        "has-value": {
-                            "version": "0.3.1",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "get-value": "^2.0.3",
-                                "has-values": "^0.1.4",
-                                "isobject": "^2.0.0"
-                            },
-                            "dependencies": {
-                                "isobject": {
-                                    "version": "2.1.0",
-                                    "bundled": true,
-                                    "dev": true,
-                                    "requires": {
-                                        "isarray": "1.0.0"
-                                    }
-                                }
-                            }
-                        },
-                        "has-values": {
-                            "version": "0.1.4",
-                            "bundled": true,
-                            "dev": true
-                        }
-                    }
-                },
-                "urix": {
-                    "version": "0.1.0",
+                "uuid": {
+                    "version": "3.3.2",
                     "bundled": true,
                     "dev": true
                 },
-                "use": {
-                    "version": "3.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^6.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "6.0.2",
-                            "bundled": true,
-                            "dev": true
-                        }
-                    }
-                },
                 "validate-npm-package-license": {
-                    "version": "3.0.3",
+                    "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -6795,12 +5809,6 @@
                     "version": "2.0.0",
                     "bundled": true,
                     "dev": true
-                },
-                "window-size": {
-                    "version": "0.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
                 },
                 "wordwrap": {
                     "version": "0.0.3",
@@ -6855,17 +5863,17 @@
                     "dev": true
                 },
                 "write-file-atomic": {
-                    "version": "1.3.4",
+                    "version": "2.4.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.11",
                         "imurmurhash": "^0.1.4",
-                        "slide": "^1.1.5"
+                        "signal-exit": "^3.0.2"
                     }
                 },
                 "y18n": {
-                    "version": "3.2.1",
+                    "version": "4.0.0",
                     "bundled": true,
                     "dev": true
                 },
@@ -6875,62 +5883,31 @@
                     "dev": true
                 },
                 "yargs": {
-                    "version": "11.1.0",
+                    "version": "12.0.5",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "cliui": "^4.0.0",
-                        "decamelize": "^1.1.1",
-                        "find-up": "^2.1.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
                         "get-caller-file": "^1.0.1",
-                        "os-locale": "^2.0.0",
+                        "os-locale": "^3.0.0",
                         "require-directory": "^2.1.1",
                         "require-main-filename": "^1.0.1",
                         "set-blocking": "^2.0.0",
                         "string-width": "^2.0.0",
                         "which-module": "^2.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^9.0.2"
-                    },
-                    "dependencies": {
-                        "camelcase": {
-                            "version": "4.1.0",
-                            "bundled": true,
-                            "dev": true
-                        },
-                        "cliui": {
-                            "version": "4.1.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "string-width": "^2.1.1",
-                                "strip-ansi": "^4.0.0",
-                                "wrap-ansi": "^2.0.0"
-                            }
-                        },
-                        "yargs-parser": {
-                            "version": "9.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "camelcase": "^4.1.0"
-                            }
-                        }
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
                     }
                 },
                 "yargs-parser": {
-                    "version": "8.1.0",
+                    "version": "11.1.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0"
-                    },
-                    "dependencies": {
-                        "camelcase": {
-                            "version": "4.1.0",
-                            "bundled": true,
-                            "dev": true
-                        }
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
                     }
                 }
             }
@@ -7151,8 +6128,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                     "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "is-glob": {
                     "version": "2.0.1",
@@ -7479,9 +6455,9 @@
             }
         },
         "printf": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/printf/-/printf-0.3.0.tgz",
-            "integrity": "sha512-DlJSroT2n9nkh47D4T6BHFQvsMR0L41889ECLmdbzk2BlhN0t31/vl5mHvlWiNBCNQrqG9XfpXwqmJQ2utoYwg==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/printf/-/printf-0.5.1.tgz",
+            "integrity": "sha512-UaE/jO0hNsrvPGQEb4LyNzcrJv9Z00tsreBduOSxMtrebvoUhxiEJ4YCHX8YHf6akwfKsC2Gyv5zv47UXhMiLg==",
             "dev": true
         },
         "private": {
@@ -7512,13 +6488,13 @@
             }
         },
         "proxy-addr": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
-            "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+            "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
             "dev": true,
             "requires": {
                 "forwarded": "~0.1.2",
-                "ipaddr.js": "1.6.0"
+                "ipaddr.js": "1.8.0"
             }
         },
         "pseudomap": {
@@ -7615,47 +6591,15 @@
             "dev": true
         },
         "raw-body": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-            "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+            "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
-                "http-errors": "1.6.2",
-                "iconv-lite": "0.4.19",
+                "http-errors": "1.6.3",
+                "iconv-lite": "0.4.23",
                 "unpipe": "1.0.0"
-            },
-            "dependencies": {
-                "depd": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-                    "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-                    "dev": true
-                },
-                "http-errors": {
-                    "version": "1.6.2",
-                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-                    "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-                    "dev": true,
-                    "requires": {
-                        "depd": "1.1.1",
-                        "inherits": "2.0.3",
-                        "setprototypeof": "1.0.3",
-                        "statuses": ">= 1.3.1 < 2"
-                    }
-                },
-                "iconv-lite": {
-                    "version": "0.4.19",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-                    "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-                    "dev": true
-                },
-                "setprototypeof": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-                    "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-                    "dev": true
-                }
             }
         },
         "re-emitter": {
@@ -7824,8 +6768,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
             "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "repeat-string": {
             "version": "1.6.1",
@@ -8129,17 +7072,34 @@
             }
         },
         "socket.io": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
-            "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.2.0.tgz",
+            "integrity": "sha512-wxXrIuZ8AILcn+f1B4ez4hJTPG24iNgxBBDaJfT6MsyOhVYiTXWexGoPkd87ktJG8kQEcL/NBvRi64+9k4Kc0w==",
             "dev": true,
             "requires": {
-                "debug": "~3.1.0",
-                "engine.io": "~3.2.0",
+                "debug": "~4.1.0",
+                "engine.io": "~3.3.1",
                 "has-binary2": "~1.0.2",
                 "socket.io-adapter": "~1.1.0",
-                "socket.io-client": "2.1.1",
-                "socket.io-parser": "~3.2.0"
+                "socket.io-client": "2.2.0",
+                "socket.io-parser": "~3.3.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
             }
         },
         "socket.io-adapter": {
@@ -8149,9 +7109,9 @@
             "dev": true
         },
         "socket.io-client": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
-            "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
+            "integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
             "dev": true,
             "requires": {
                 "backo2": "1.0.2",
@@ -8159,21 +7119,21 @@
                 "component-bind": "1.0.0",
                 "component-emitter": "1.2.1",
                 "debug": "~3.1.0",
-                "engine.io-client": "~3.2.0",
+                "engine.io-client": "~3.3.1",
                 "has-binary2": "~1.0.2",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "object-component": "0.0.3",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "socket.io-parser": "~3.2.0",
+                "socket.io-parser": "~3.3.0",
                 "to-array": "0.1.4"
             }
         },
         "socket.io-parser": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
-            "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+            "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
             "dev": true,
             "requires": {
                 "component-emitter": "1.2.1",
@@ -8561,9 +7521,9 @@
             }
         },
         "testem": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/testem/-/testem-2.8.2.tgz",
-            "integrity": "sha512-habhmMQgXMXMB64aMslMyADxuXDcLJzFqaXRc6mjQxvHk6WaLvq0sZAbTcDxmLW/XHdsylwgRXzG4T7EoVtnDw==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/testem/-/testem-2.14.0.tgz",
+            "integrity": "sha512-tldpNPCzXfibmxOoTMGOfr8ztUiHf9292zSXCu7SitBx9dCK83k7vEoa77qJBS9t3RGCQCRF+GNMUuiFw//Mbw==",
             "dev": true,
             "requires": {
                 "backbone": "^1.1.2",
@@ -8571,7 +7531,7 @@
                 "charm": "^1.0.0",
                 "commander": "^2.6.0",
                 "consolidate": "^0.15.1",
-                "execa": "^0.10.0",
+                "execa": "^1.0.0",
                 "express": "^4.10.7",
                 "fireworm": "^0.7.0",
                 "glob": "^7.0.4",
@@ -8583,16 +7543,66 @@
                 "lodash.find": "^4.5.1",
                 "lodash.uniqby": "^4.7.0",
                 "mkdirp": "^0.5.1",
-                "mustache": "^2.2.1",
+                "mustache": "^3.0.0",
                 "node-notifier": "^5.0.1",
                 "npmlog": "^4.0.0",
-                "printf": "^0.3.0",
+                "printf": "^0.5.1",
                 "rimraf": "^2.4.4",
                 "socket.io": "^2.1.0",
                 "spawn-args": "^0.2.0",
                 "styled_string": "0.0.1",
                 "tap-parser": "^7.0.0",
+                "tmp": "0.0.33",
                 "xmldom": "^0.1.19"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "pump": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                }
             }
         },
         "text-table": {
@@ -8743,12 +7753,6 @@
                 "lodash.unescape": "4.0.1",
                 "semver": "5.5.0"
             }
-        },
-        "ultron": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-            "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-            "dev": true
         },
         "unc-path-regex": {
             "version": "0.1.2",
@@ -9081,14 +8085,12 @@
             }
         },
         "ws": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-            "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+            "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
             "dev": true,
             "requires": {
-                "async-limiter": "~1.0.0",
-                "safe-buffer": "~5.1.0",
-                "ultron": "~1.1.0"
+                "async-limiter": "~1.0.0"
             }
         },
         "xmldom": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:extension.vscode-wsl-workspaceFolder"
+    "onCommand:extension.vscode-wsl-workspaceFolder",
+    "onCommand:extension.vscode-wsl-workspaceCurrentFile"
   ],
   "main": "./lib",
   "contributes": {
@@ -40,6 +41,10 @@
       {
         "command": "extension.vscode-wsl-workspaceFolder",
         "title": "WSL workspaceFolder"
+      },
+      {
+        "command": "extension.vscode-wsl-workspaceCurrentFile",
+        "title": "WSL Current File"
       }
     ]
   },
@@ -67,13 +72,13 @@
     "eslint-plugin-react": "^7.10.0",
     "esm": "^3.0.65",
     "minimist": "^1.2.0",
-    "nyc": "^12.0.2",
+    "nyc": "^13.3.0",
     "opn": "^5.3.0",
     "prettier-eslint-cli": "^4.7.1",
     "tap-spec": "^5.0.0",
     "tape": "^4.9.1",
     "tape-promise": "^3.0.0",
-    "testem": "^2.8.2"
+    "testem": "^2.14.0"
   },
   "dependencies": {
     "debug": "^3.1.0",


### PR DESCRIPTION
Added a new command `extension.vscode-wsl-workspaceCurrentFile`, which provides the VS Code predefined variable `${file}` (the path to the currently opened file) in Unix (WSL) path style. I find this hugely helpful for creating Mocha test debug profiles, so I can just run the current file. 

This also updates a couple NPM packages to address some vulnerabilities alerted by `npm audit`.